### PR TITLE
Fix typo in config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -86,7 +86,7 @@ dns:
     # === Apple Software Update Service ===
     - 'swscan.apple.com'
     - 'mesu.apple.com'
-    # === Windows 10 Connnect Detection ===
+    # === Windows 10 Connect Detection ===
     - '*.msftconnecttest.com'
     - '*.msftncsi.com'
     # === NTP Service ===


### PR DESCRIPTION
## Summary
- fix `Connnect` typo in config.yaml

## Testing
- `grep -n Connnect config.yaml`

------
https://chatgpt.com/codex/tasks/task_e_6840721ddd0483218308c616c1332b2d